### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Docker files
+# Docker files
 
 * [Building Android ubuntu 16.04 (with NDK)](ubuntu-16-04-java7-8/README.md)
 * [Building Android ubuntu 14.04 (with NDK)](java7-8/README.md)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
